### PR TITLE
Point to src/webgl.ts in package.json ascMain entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aswebglue",
   "version": "0.1.2",
-  "ascMain": "webgl.ts",
+  "ascMain": "src/webgl.ts",
   "main": "src/ASWebGLue.js",
   "types": "src/ASWebGLue.d.ts",
   "repository": {


### PR DESCRIPTION
Should fix `import ... from "aswebglue"` usage, as just `webgl.ts` points to a non-existing file currently.